### PR TITLE
Revert ORM to datamapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Blog
+
+## Chris Loewer
+
+**Installation tips**
+
+ruby dev kit
+```sudo apt-get install ruby-dev```
+
+sqlite headers
+```sudo apt-get install libgmp3-dev```

--- a/blog.rb
+++ b/blog.rb
@@ -2,7 +2,8 @@ require 'sinatra'
 require 'data_mapper'
 require 'json'
 
-set :port, 12008
+set :port, 12568
+set :environment, :production
 
 # DATABASE
 DataMapper::setup(:default, "sqlite3://#{Dir.pwd}/posts.db")


### PR DESCRIPTION
Datamapper gem now correctly installed on server allowing for this to be used instead.
